### PR TITLE
Integrate BlocklyAutomation UI and start/stop APIs

### DIFF
--- a/src/AspireResourceExtensions/AspireResourceExtensionsAspire/AspireResource.cs
+++ b/src/AspireResourceExtensions/AspireResourceExtensionsAspire/AspireResource.cs
@@ -187,7 +187,7 @@ public class AspireResource : Resource, IResourceWithEnvironment, IResourceWithE
         app.MapPost("/api/aspire/resources/{name}/execute/{command}", async Task<Results<Ok<ExecuteCommandResult>, NotFound<string>>> (string name,string command) =>
         {
             if (!myApp.ExistResource(name))
-                return TypedResults.NotFound($"cannot find command {command} on {name}");
+                return TypedResults.NotFound($"resource '{name}' was not found");
 
             var res = await resourceCommands.ExecuteCommandAsync(name, command);  
             return TypedResults.Ok(res);
@@ -196,7 +196,7 @@ public class AspireResource : Resource, IResourceWithEnvironment, IResourceWithE
         {
             string command= KnownResourceCommands.StartCommand;
             if (!myApp.ExistResource(name))
-                return TypedResults.NotFound($"cannot find command {command} on {name}");
+                return TypedResults.NotFound($"resource '{name}' was not found");
 
             var res = await resourceCommands.ExecuteCommandAsync(name, command);
             return TypedResults.Ok(res);
@@ -205,7 +205,7 @@ public class AspireResource : Resource, IResourceWithEnvironment, IResourceWithE
         {
             string command = KnownResourceCommands.StopCommand;
             if (!myApp.ExistResource(name))
-                return TypedResults.NotFound($"cannot find command {command} on {name}");
+                return TypedResults.NotFound($"resource '{name}' was not found");
 
             var res = await resourceCommands.ExecuteCommandAsync(name, command);
             return TypedResults.Ok(res);

--- a/src/AspireResourceExtensions/AspireResourceExtensionsAspire/AspireResource.cs
+++ b/src/AspireResourceExtensions/AspireResourceExtensionsAspire/AspireResource.cs
@@ -118,9 +118,7 @@ public class AspireResource : Resource, IResourceWithEnvironment, IResourceWithE
         builder.Services.AddOpenApi();
         builder.Services.AddCors();
 
-
-        var p = builder.Environment.WebRootFileProvider;
-        builder.Environment.WebRootFileProvider= MapFileProvider.Manifest(builder);
+        builder.Environment.WebRootFileProvider = MapFileProvider.Manifest(builder);
         var app = builder.Build();
 
         //var staticUiPath = ResolveStaticUiPath();

--- a/src/AspireResourceExtensions/AspireResourceExtensionsAspire/AspireResource.cs
+++ b/src/AspireResourceExtensions/AspireResourceExtensionsAspire/AspireResource.cs
@@ -1,4 +1,6 @@
 ﻿
+using NetCore2BlocklyNew;
+
 namespace AspireResourceExtensionsAspire;
 
 public class AspireResource : Resource, IResourceWithEnvironment, IResourceWithEndpoints, IResourceWithServiceDiscovery
@@ -29,12 +31,15 @@ public class AspireResource : Resource, IResourceWithEnvironment, IResourceWithE
 
 
         var ret = await AddAspire.ViewData(da);
-        _loginUrl = ret??"";
+        _loginUrl = ret ?? "";
         if (ret == null)
         {
             return _loginUrl;
         }
-        string webServer = await StartWebServerAsync(myApp, da.ResourceCommands, ret)??"";        
+        string webServer = await StartWebServerAsync(myApp, 
+            da.ResourceCommands, 
+            da.ResourceNotifications,
+            ret) ?? "";
         //var env = await this.GetEnvironmentVariableValuesAsync();
         await da.ResourceNotifications.PublishUpdateAsync(this, mainState =>
         {
@@ -99,8 +104,32 @@ public class AspireResource : Resource, IResourceWithEnvironment, IResourceWithE
 
         return ret;
     }
+    //private static string ResolveStaticUiPath()
+    //{
+    //    foreach (var startingDirectory in GetSearchDirectories())
+    //    {
+    //        for (var directory = new DirectoryInfo(startingDirectory); directory is not null; directory = directory.Parent)
+    //        {
+    //            var candidate = Path.Combine(directory.FullName, "AspireResourceExtensionsAspire", "wwwroot");
+    //            if (File.Exists(Path.Combine(candidate, "index.html")))
+    //            {
+    //                return candidate;
+    //            }
+    //        }
+    //    }
 
-    internal async Task<string?> StartWebServerAsync(MyAppResource myApp, ResourceCommandService resourceCommands, string aspireUrl)
+    //    throw new DirectoryNotFoundException("Could not find AspireResourceCommand\\wwwroot containing index.html.");
+    //}
+    private static IEnumerable<string> GetSearchDirectories()
+    {
+        yield return Directory.GetCurrentDirectory();
+        yield return AppContext.BaseDirectory;
+    }
+
+    internal async Task<string?> StartWebServerAsync(
+        MyAppResource myApp, ResourceCommandService resourceCommands,
+        ResourceNotificationService resourceNotificationService,
+        string aspireUrl)
     {
         var port = new Uri(aspireUrl).Port;
         var newPort = port + 1;
@@ -110,9 +139,27 @@ public class AspireResource : Resource, IResourceWithEnvironment, IResourceWithE
         builder.Services.AddOpenApi();
         builder.Services.AddCors();
 
+
         var p = builder.Environment.WebRootFileProvider;
         builder.Environment.WebRootFileProvider= MapFileProvider.Manifest(builder);
         var app = builder.Build();
+
+        //var staticUiPath = ResolveStaticUiPath();
+        var fp = builder.Environment.WebRootFileProvider;
+        app.UseDefaultFiles(new DefaultFilesOptions
+        {
+            FileProvider = fp
+        });
+        app.UseStaticFiles(new StaticFileOptions
+        {
+            FileProvider = fp
+        });
+
+        Extensions.FileProvider = fp;
+        app.UseBlocklyUI(app.Environment,registerStaticAndDefaultFiles:false);
+        //after app.MapControllers();
+        app.UseBlocklyAutomation();
+
         //MapFileProvider.mapFile("wwwroot", prov, app);
         //app.Urls.Add("http://127.0.0.1:0");
         app.UseCors(it =>
@@ -128,10 +175,10 @@ public class AspireResource : Resource, IResourceWithEnvironment, IResourceWithE
         app.MapOpenApi("/openapi/{documentName}.yaml");
 
         app.Urls.Add($"http://127.0.0.1:{newPort}");
-        // Serve static files from a "wwwroot" directory
+        //// Serve static files from a "wwwroot" directory
         
-        app.UseDefaultFiles();
-        app.UseStaticFiles();
+        //app.UseDefaultFiles();
+        //app.UseStaticFiles();
         
         
         app.MapGet("/api/aspire/resources/export/mermaid", ()=>myApp.ExportToMermaid());
@@ -139,7 +186,21 @@ public class AspireResource : Resource, IResourceWithEnvironment, IResourceWithE
 
         app.MapGet("/api/aspire/resources/", () =>
         {
-            return myApp.MyResources();
+            Dictionary<string, string> state = new();
+        var resources = myApp.MyResources();
+            foreach (var resource in resources)
+            {
+                var stateRes ="Unknown";
+                if (resourceNotificationService.TryGetCurrentState(resource, out var currentState))
+                {
+                    stateRes = currentState?.Snapshot?.State?.Text ?? stateRes;
+                }
+                
+                state[resource] = stateRes;
+                
+            }
+            return state.ToArray();
+
         });
         app.MapGet("/api/aspire/resources/{name}", (string name) =>
         {
@@ -152,6 +213,24 @@ public class AspireResource : Resource, IResourceWithEnvironment, IResourceWithE
                 return TypedResults.NotFound($"cannot find command {command} on {name}");
 
             var res = await resourceCommands.ExecuteCommandAsync(name, command);  
+            return TypedResults.Ok(res);
+        });
+        app.MapPost("/api/aspire/resources/{name}/start", async Task<Results<Ok<ExecuteCommandResult>, NotFound<string>>> (string name) =>
+        {
+            string command= KnownResourceCommands.StartCommand;
+            if (!myApp.ExistResource(name))
+                return TypedResults.NotFound($"cannot find command {command} on {name}");
+
+            var res = await resourceCommands.ExecuteCommandAsync(name, command);
+            return TypedResults.Ok(res);
+        });
+        app.MapPost("/api/aspire/resources/{name}/stop", async Task<Results<Ok<ExecuteCommandResult>, NotFound<string>>> (string name) =>
+        {
+            string command = KnownResourceCommands.StopCommand;
+            if (!myApp.ExistResource(name))
+                return TypedResults.NotFound($"cannot find command {command} on {name}");
+
+            var res = await resourceCommands.ExecuteCommandAsync(name, command);
             return TypedResults.Ok(res);
         });
 

--- a/src/AspireResourceExtensions/AspireResourceExtensionsAspire/AspireResource.cs
+++ b/src/AspireResourceExtensions/AspireResourceExtensionsAspire/AspireResource.cs
@@ -104,27 +104,6 @@ public class AspireResource : Resource, IResourceWithEnvironment, IResourceWithE
 
         return ret;
     }
-    //private static string ResolveStaticUiPath()
-    //{
-    //    foreach (var startingDirectory in GetSearchDirectories())
-    //    {
-    //        for (var directory = new DirectoryInfo(startingDirectory); directory is not null; directory = directory.Parent)
-    //        {
-    //            var candidate = Path.Combine(directory.FullName, "AspireResourceExtensionsAspire", "wwwroot");
-    //            if (File.Exists(Path.Combine(candidate, "index.html")))
-    //            {
-    //                return candidate;
-    //            }
-    //        }
-    //    }
-
-    //    throw new DirectoryNotFoundException("Could not find AspireResourceCommand\\wwwroot containing index.html.");
-    //}
-    private static IEnumerable<string> GetSearchDirectories()
-    {
-        yield return Directory.GetCurrentDirectory();
-        yield return AppContext.BaseDirectory;
-    }
 
     internal async Task<string?> StartWebServerAsync(
         MyAppResource myApp, ResourceCommandService resourceCommands,

--- a/src/AspireResourceExtensions/AspireResourceExtensionsAspire/AspireResourceExtensionsAspire.csproj
+++ b/src/AspireResourceExtensions/AspireResourceExtensionsAspire/AspireResourceExtensionsAspire.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <!-- NuGet package metadata -->
     <PackageId>AspireExtensionsResource</PackageId>
-    <Version>130.2025.1121.547</Version>
+    <Version>130.2026.316.547</Version>
 	<Authors>Ignat Andrei</Authors>
     <Company>AOM</Company>
 	  <RepositoryType>git</RepositoryType>
@@ -49,6 +49,7 @@
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
+		<PackageReference Include="NetCore2Blockly" Version="10.2026.316.550" />
 		<PackageReference Include="RazorBlade" Version="0.11.0" PrivateAssets="all" ReferenceOutputAssembly="false" OutputItemType="Analyzer" />
 
 	</ItemGroup>

--- a/src/AspireResourceExtensions/AspireResourceExtensionsAspire/wwwroot/BlocklyAutomation/assets/settings.json
+++ b/src/AspireResourceExtensions/AspireResourceExtensionsAspire/wwwroot/BlocklyAutomation/assets/settings.json
@@ -1,0 +1,157 @@
+{
+    "title": "Automation",
+    "footer": "Please give us a star on https://github.com/ignatandrei/BlocklyAutomation",
+    "localAPI": "http://localhost:37283/",
+  "startBlocks": [
+    "<xml xmlns='https://developers.google.com/blockly/xml'>",
+    "<block type='metadisplay' x='0' y='0'>",
+    "    <field name='what'>4</field>",
+    "    <next>",
+    "      <block type='text_print'>",
+    "        <value name='TEXT'>",
+    "          <block type='HTMLheaders'>",
+    "            <field name='NAME'>H1</field>",
+    "            <value name='NAME'>",
+    "              <shadow type='text'>",
+    "                <field name='TEXT'></field>",
+    "              </shadow>",
+    "              <block type='text'>",
+    "                <field name='TEXT'>See 'swaggers' menu on left for how to run Start/ Stop in aspire </field>",
+    "              </block>",
+    "            </value>",
+    "          </block>",
+    "        </value>",
+    "        <next>",
+    "          <block type='text_print'>",
+    "            <value name='TEXT'>",
+    "              <block type='convertToTable'>",
+    "                <value name='ArrayToConvert'>",
+    "                  <block type='get__api_aspire_resources'></block>",
+    "                </value>",
+    "              </block>",
+    "            </value>",
+    "            <next>",
+    "              <block type='text_print'>",
+    "                <value name='TEXT'>",
+    "                  <block type='post__api_aspire_resources___name_stop'>",
+    "                    <value name='val_name'>",
+    "                      <block type='text'>",
+    "                        <field name='TEXT'>apiservice</field>",
+    "                      </block>",
+    "                    </value>",
+    "                  </block>",
+    "                </value>",
+    "                <next>",
+    "                  <block type='wait_seconds'>",
+    "                    <field name='SECONDS'>10</field>",
+    "                    <next>",
+    "                      <block type='text_print'>",
+    "                        <value name='TEXT'>",
+    "                          <block type='convertToTable'>",
+    "                            <value name='ArrayToConvert'>",
+    "                              <block type='get__api_aspire_resources'></block>",
+    "                            </value>",
+    "                          </block>",
+    "                        </value>",
+    "                        <next>",
+    "                          <block type='text_print'>",
+    "                            <value name='TEXT'>",
+    "                              <block type='post__api_aspire_resources___name_start'>",
+    "                                <value name='val_name'>",
+    "                                  <block type='text'>",
+    "                                    <field name='TEXT'>apiservice</field>",
+    "                                  </block>",
+    "                                </value>",
+    "                              </block>",
+    "                            </value>",
+    "                            <next>",
+    "                              <block type='wait_seconds'>",
+    "                                <field name='SECONDS'>10</field>",
+    "                                <next>",
+    "                                  <block type='text_print'>",
+    "                                    <value name='TEXT'>",
+    "                                      <block type='convertToTable'>",
+    "                                        <value name='ArrayToConvert'>",
+    "                                          <block type='get__api_aspire_resources'></block>",
+    "                                        </value>",
+    "                                      </block>",
+    "                                    </value>",
+    "                                  </block>",
+    "                                </next>",
+    "                              </block>",
+    "                            </next>",
+    "                          </block>",
+    "                        </next>",
+    "                      </block>",
+    "                    </next>",
+    "                  </block>",
+    "                </next>",
+    "              </block>",
+    "            </next>",
+    "          </block>",
+    "        </next>",
+    "      </block>",
+    "    </next>",
+    "  </block>",
+    "</xml>"
+  ],
+    "hideMenu":false,
+  "tourSteps":
+    [
+      {
+          "text":"This is the  help tour",
+          "query":".blocklyWorkspace"          
+      },
+      {
+        "text": "You can start with help first",
+        "query":".btnHelp"
+      },
+      {
+        "text":"Here you can find blocks for VisualCode  API ! Expand to investigate and drag",
+        "query":".blocklyToolboxContents"
+      },
+      
+      {
+        "text":"Here you can find blocks for basic constructs : loops, text, bool, logic ...",
+        "query":".blocklyTreeLabel"
+      }
+      ,
+      
+      {
+        "text":"If you are a programmer, you can find your swagger at the left -we have package for Java, .NET , Node, PHP <a href='https://github.com/ignatandrei/Blocklyautomation' target='_blank'>VisualAPI</a>",
+        "query":""
+      },
+      
+      {
+        "text":"Drag here blocks to execute them",
+        "query":".blocklyBlockCanvas"
+      }
+      ,
+      {
+          "text":"Here you will find examples to get started",
+          "query":".stepTourDemos"
+      },
+      {
+          "text":"to reuse you can download / load  the blocks from here",
+          "query":".stepTourDownload"
+      },
+      {
+          "text":"Press the execute button to run ;-) ",
+          "query":".stepTourRunButton"
+      },
+      
+      {
+          "text":"Press the output button to see the result of blocks",
+          "query":".stepTourOutputButton"
+      }
+      ,{
+        "text":"Here you can find the output as text, html and json",
+        "query":".stepTourOutput"
+      },
+      {
+          "text":"Now press execute and see , via HTTP, a joke with Chuck Norris ",
+          "query":".stepTourRunButton"
+      }
+      
+  ]
+}

--- a/src/AspireResourceExtensions/AspireResourceExtensionsAspire/wwwroot/index.html
+++ b/src/AspireResourceExtensions/AspireResourceExtensionsAspire/wwwroot/index.html
@@ -14,7 +14,7 @@
         json
     </h1>
     <ul>
-        <li><a href="/blocklyAutomation">Start and stop Visual Macro</a></li>
+        <li><a href="/BlocklyAutomation">Start and stop Visual Macro</a></li>
         <li><a href="openapi/v1.json" target="_blank">Swagger json</a></li>
         <li><a href="openapi/v1.yaml" target="_blank">Swagger yaml</a></li>
         <li>

--- a/src/AspireResourceExtensions/AspireResourceExtensionsAspire/wwwroot/index.html
+++ b/src/AspireResourceExtensions/AspireResourceExtensionsAspire/wwwroot/index.html
@@ -14,6 +14,7 @@
         json
     </h1>
     <ul>
+        <li><a href="/blocklyAutomation">Start and stop Visual Macro</a></li>
         <li><a href="openapi/v1.json" target="_blank">Swagger json</a></li>
         <li><a href="openapi/v1.yaml" target="_blank">Swagger yaml</a></li>
         <li>

--- a/src/AspireResourceExtensions/README.md
+++ b/src/AspireResourceExtensions/README.md
@@ -58,6 +58,10 @@ await Task.WhenAll(app.RunAsync(), result);
 
 ## Integrations
 
+### Poor Chaos Monkey
+
+Goto Aspire Resource URL/BlocklyAutomation and you can start and stop services 
+
 ### Playwright NodeJS 
 
 Suppose that you have a NodeJS playwright app that you want to test your ASPIRE dashboard. You can integrate this way : In AppHost.cs

--- a/src/AspireResourceExtensions/README.md
+++ b/src/AspireResourceExtensions/README.md
@@ -60,7 +60,7 @@ await Task.WhenAll(app.RunAsync(), result);
 
 ### Poor Chaos Monkey
 
-Goto Aspire Resource URL/BlocklyAutomation and you can start and stop services 
+Go to the Aspire Resource URL at /BlocklyAutomation to start or stop services.
 
 ### Playwright NodeJS 
 


### PR DESCRIPTION
Add BlocklyAutomation assets and wire up UI and control endpoints. Bump package version and add NetCore2Blockly dependency. Changes include: add wwwroot/BlocklyAutomation/assets/settings.json and index.html link; update AspireResource to use NetCore2BlocklyNew, map manifest file provider, enable Blockly UI/static files, pass ResourceNotificationService into StartWebServerAsync, include resource runtime state in /api/aspire/resources, and add POST endpoints to start/stop named resources. Also add helper GetSearchDirectories and update README to mention the new Visual Macro (BlocklyAutomation) feature.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Blockly Automation UI for visual automation to start/stop services.
  * Added API endpoints to start and stop individual resources.
  * Resource API now returns current state information per resource.

* **Documentation**
  * Added integration note pointing to the Blockly Automation UI.
  * Included prebuilt automation settings and an interactive tour for onboarding.

* **Chores**
  * Project package/version metadata updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->